### PR TITLE
Fix logging: write logs to user AppData folder instead of install dir…

### DIFF
--- a/bubble_analyser/__main__.py
+++ b/bubble_analyser/__main__.py
@@ -1,10 +1,11 @@
 """The entry point for the Bubble Analyser program."""
 
-import os
 import logging
+import os
+import platform
 import tempfile
 from pathlib import Path
-import platform
+
 
 def setup_basic_logging() -> None:
     """Set up cross-platform, user-writable logging before the main app runs."""
@@ -30,11 +31,10 @@ def setup_basic_logging() -> None:
         level=logging.INFO,
         format="%(asctime)s - %(levelname)s - %(message)s",
         handlers=[
-            logging.FileHandler(log_file, encoding='utf-8'),
+            logging.FileHandler(log_file, encoding="utf-8"),
             logging.StreamHandler(),
         ],
     )
-
 
 
 if __name__ == "__main__":
@@ -70,4 +70,3 @@ if __name__ == "__main__":
         except Exception:
             # If we can't show a dialog, at least the error is logged and printed
             pass
-

--- a/bubble_analyser/__main__.py
+++ b/bubble_analyser/__main__.py
@@ -1,27 +1,26 @@
 """The entry point for the Bubble Analyser program."""
 
+import os
 import logging
-import sys
-import traceback
+import tempfile
 from pathlib import Path
+import platform
 
-
-# Set up basic logging in case an error occurs before the main logging is configured
 def setup_basic_logging() -> None:
-    """Set up basic logging to ensure errors are captured before main logging is configured."""
-    # Use user's home directory or temporary directory for logs
-    import tempfile
-
-    # Try to use the user's application data directory first
-    user_home = Path.home()
-    app_data_dir = user_home / "Library" / "Application Support" / "BubbleAnalyser"
-
+    """Set up cross-platform, user-writable logging before the main app runs."""
     try:
-        app_data_dir.mkdir(parents=True, exist_ok=True)
+        system = platform.system()
+        if system == "Windows":
+            app_data_dir = Path(os.getenv("LOCALAPPDATA", Path.home() / "AppData" / "Local")) / "BubbleAnalyser"
+        elif system == "Darwin":
+            app_data_dir = Path.home() / "Library" / "Application Support" / "BubbleAnalyser"
+        else:  # Linux or other Unix-like
+            app_data_dir = Path(os.getenv("XDG_DATA_HOME", Path.home() / ".local" / "share")) / "BubbleAnalyser"
+
         logs_dir = app_data_dir / "logs"
-        logs_dir.mkdir(exist_ok=True)
-    except OSError:
-        # Fallback to temp directory if we can't write to app data dir
+        logs_dir.mkdir(parents=True, exist_ok=True)
+    except Exception:
+        # Fallback to temporary directory
         logs_dir = Path(tempfile.gettempdir()) / "BubbleAnalyser" / "logs"
         logs_dir.mkdir(parents=True, exist_ok=True)
 
@@ -31,10 +30,11 @@ def setup_basic_logging() -> None:
         level=logging.INFO,
         format="%(asctime)s - %(levelname)s - %(message)s",
         handlers=[
-            logging.FileHandler(log_file),
+            logging.FileHandler(log_file, encoding='utf-8'),
             logging.StreamHandler(),
         ],
     )
+
 
 
 if __name__ == "__main__":
@@ -70,3 +70,4 @@ if __name__ == "__main__":
         except Exception:
             # If we can't show a dialog, at least the error is logged and printed
             pass
+


### PR DESCRIPTION
…ectory

Replaced the previous `setup_basic_logging()` implementation to avoid PermissionError when the app tries to create a 'logs' directory in the install location (e.g., Program Files). 

The new version detects the correct user-specific application data directory depending on the OS (e.g., LOCALAPPDATA on Windows, Application Support on macOS), and stores logs there instead.

Also includes a fallback to the system temp directory in case access is denied or the path can't be resolved.

This fix should make the app safe to run as a regular user and avoid crashes during startup when installed via the Inno Setup wizard. It does not change any other behaviour.

Please test by packaging a new .exe and running it without admin privileges.

# Description

_Please include a summary of the change and which issue is fixed (if any). Please also
include relevant motivation and context. List any dependencies that are required for
this change._

Fixes # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
